### PR TITLE
Update aliasa-user-interface to address dependency vulnerabilities

### DIFF
--- a/aliada/aliada-user-interface/pom.xml
+++ b/aliada/aliada-user-interface/pom.xml
@@ -78,9 +78,15 @@
 		</dependency>
 
 		<dependency>
+			<groupId>commons-beanutils</groupId>
+			<artifactId>commons-beanutils</artifactId>
+			<version>1.9.3</version>
+		</dependency>
+		
+		<dependency>
 		    <groupId>commons-fileupload</groupId>
 		    <artifactId>commons-fileupload</artifactId>
-		    <version>1.1.1</version>
+		    <version>1.3.2</version>
 		</dependency>
 
 		<dependency>
@@ -88,24 +94,24 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.4</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>com.googlecode.json-simple</groupId>
 			<artifactId>json-simple</artifactId>
 			<version>1.1.1</version>
-		</dependency>		
-		
+		</dependency>
+
 		<dependency>
 			<groupId>com.jgeppert.struts2.jquery</groupId>
 			<artifactId>struts2-jquery-plugin</artifactId>
 			<version>3.6.1</version>
-		</dependency>	
-			
+		</dependency>
+
 		<dependency>
 			<groupId>org.jasypt</groupId>
 			<artifactId>jasypt</artifactId>
 			<version>1.9.0</version>
 		</dependency>
-		
+
 	</dependencies>
 </project>


### PR DESCRIPTION
@agazzarini: These are the changes that I made on Stanford's fork or Aliada. I tested the app and everything appears to be working (and all of the build tests pass). Please review at your convenience and merge if you see fit. The changes address the following vulnerabilities:

- https://www.cvedetails.com/cve/CVE-2014-0114/
- http://www.cvedetails.com/cve/CVE-2015-6420/
- https://www.cvedetails.com/vulnerability-list/vendor_id-45/product_id-24746/Apache-Commons-Fileupload.html

The newer (good) JARs that will be downloaded are:

commons-beanutils-1.9.3.jar
commons-collections-3.2.2.jar
commons-fileupload-1.3.2.jar